### PR TITLE
Adding History-related grunt tasks

### DIFF
--- a/tasks/help.js
+++ b/tasks/help.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
             ['history-rollup', 'Creates History Rollup file (Run before history-replace)'],
             ['history-populate', 'Populates History files with @VERSION@ if not there already'],
             ['history-replace', 'Replaces @VERSION@ in History files with *release-version*'],
-            ['help', 'Show this stuffs'],
+            ['help', 'Show this stuffs']
         ], len = 0,
         pad = function(line) {
             for (var i = line.length; i < len; i++) {

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -20,7 +20,10 @@ module.exports = function(grunt) {
             ['test', 'Test the library with ' + 'yogi'.magenta],
             ['test-cli', 'Test the library via CLI with ' + 'yogi'.magenta],
             ['travis', 'Perform a travis test (uses enviroment vars to determine tests)'],
-            ['help', 'Show this stuffs']
+            ['history-rollup', 'Creates History Rollup file (Run before history-replace)'],
+            ['history-populate', 'Populates History files with @VERSION@ if not there already'],
+            ['history-replace', 'Replaces @VERSION@ in History files with *release-version*'],
+            ['help', 'Show this stuffs'],
         ], len = 0,
         pad = function(line) {
             for (var i = line.length; i < len; i++) {
@@ -32,7 +35,7 @@ module.exports = function(grunt) {
             ['--release-build=<BUILD>', 'Pass to set the build number of the release, if not passed the git sha will be used.'],
             ['--cache-build', 'Cache the ' + 'shifter'.magenta + ' build.'.white]
         ];
-        
+
         help.forEach(function(item) {
             var line = item[0];
             if (line.length > len) {
@@ -43,7 +46,7 @@ module.exports = function(grunt) {
         help.forEach(function(item) {
             grunt.log.writeln(pad(item[0]) +  item[1].white);
         });
-        
+
         grunt.log.writeln('');
         grunt.log.ok('Options:');
         grunt.log.writeln('');
@@ -59,7 +62,7 @@ module.exports = function(grunt) {
         opts.forEach(function(item) {
             grunt.log.writeln(pad(item[0]) +  item[1].white);
         });
-        
+
     });
 
 };

--- a/tasks/history.js
+++ b/tasks/history.js
@@ -3,8 +3,7 @@ Copyright (c) 2013, Yahoo! Inc. All rights reserved.
 Code licensed under the BSD License:
 http://yuilibrary.com/license/
 */
-var path = require('path'),
-    exec = require('child_process').spawn;
+var path = require('path');
 
 
 module.exports = function(grunt) {
@@ -36,7 +35,7 @@ module.exports = function(grunt) {
                 content = content.split(key)[0];
                 //grunt.log.writeln(content);
 
-                if(content && content.search(token) && content.search(noChanges) == -1){
+                if(content && content.search(token) && content.search(noChanges) === -1){
                     grunt.log.writeln("Found content in " + abspath);
                     grunt.log.writeln(">>> adding to buffer");
                     output += "\n" +content;
@@ -113,7 +112,7 @@ module.exports = function(grunt) {
                     contentMatch = content.match(token);
 
                 if(contentMatch){
-                    if(contentMatch.length == 1){
+                    if(contentMatch.length === 1){
                         grunt.log.writeln("Found exactly 1 @VERSION@ in " + abspath);
 
                         newContent = content.replace(token,VERSION);

--- a/tasks/history.js
+++ b/tasks/history.js
@@ -1,0 +1,143 @@
+/*
+Copyright (c) 2013, Yahoo! Inc. All rights reserved.
+Code licensed under the BSD License:
+http://yuilibrary.com/license/
+*/
+var path = require('path'),
+    exec = require('child_process').spawn;
+
+
+module.exports = function(grunt) {
+    var start,
+        VERSION,
+        historyName = "HISTORY.md",
+              token = /@VERSION@/gi,
+          noChanges = /No changes./,
+                key = "\n3.";
+
+    grunt.registerTask('history-rollup', 'Create the history rollup file.', function(){
+
+        var output = '',
+        rollupName = "HISTORYROLLUP.md",
+         fileCount = 0,
+        destination;
+
+        start = path.join(process.cwd(), 'src');
+        destination = path.join(process.cwd(), rollupName);
+        VERSION = grunt.config.get('version');
+
+
+        grunt.log.writeln("History Rollup Creation starting...");
+        grunt.log.writeln("Starting in: "+start);
+
+        grunt.file.recurse(start, function(abspath,rootdir,subdir,filename){
+            if(filename === historyName){
+                var content = grunt.file.read(abspath);
+                content = content.split(key)[0];
+                //grunt.log.writeln(content);
+
+                if(content && content.search(token) && content.search(noChanges) == -1){
+                    grunt.log.writeln("Found content in " + abspath);
+                    grunt.log.writeln(">>> adding to buffer");
+                    output += "\n" +content;
+                    fileCount++;
+                }
+            }
+
+
+        });
+
+        // report findings
+        grunt.log.writeln("Finished scanning files.");
+        grunt.log.writeln("Added "+ fileCount + " entries.");
+
+        // done recursing now write to file
+        if(output !== ""){
+            grunt.file.write(destination, output);
+            grunt.log.writeln("Wrote to file: " + destination);
+        }
+
+
+
+    });
+
+    grunt.registerTask('history-populate', 'Populate history files with @VERSION@ if not there already.', function (){
+        var nochanges = "\n@VERSION@\n------\n\n* No changes.\n",
+            fileCount = 0,
+            content,
+            newContent,
+            contArr;
+
+        start = path.join(process.cwd(), 'src');
+
+        grunt.log.writeln("History Populate starting...");
+
+
+        grunt.file.recurse(start, function(abspath,rootdir,subdir,filename){
+            if(filename === historyName){
+                content = grunt.file.read(abspath);
+
+                if(content.match(token) !== null){
+                    grunt.log.writeln("Found a @VERSION@ in " + abspath + " skipping...");
+                } else {
+                    grunt.log.writeln("No @VERSION@ found. Adding to : " + abspath);
+                    contArr = content.split(key);
+                    grunt.log.writeln(contArr.length);
+                    contArr[0] = contArr[0] + nochanges; // add new history entry.
+                    newContent = contArr.join(key);
+                    grunt.file.write(abspath, newContent); //overwrite old HISTORY.md
+                    fileCount++;
+                }
+            }
+        });
+
+        grunt.log.writeln("History Populate done. Files changed: "+ fileCount);
+
+
+
+    });
+
+    grunt.registerTask('history-replace', 'Replace @VERSION@ with current release version.', function(){
+        var fileCount = 0;
+
+        start = path.join(process.cwd(), 'src');
+        VERSION = grunt.config.get('version');
+
+        grunt.log.writeln("History Version Replace starting...");
+        grunt.log.writeln("Using release version: " + VERSION);
+
+        grunt.file.recurse(start, function(abspath,rootdir,subdir,filename){
+            if(filename === historyName){
+                var content = grunt.file.read(abspath),
+                    newContent,
+                    contentMatch = content.match(token);
+
+                if(contentMatch){
+                    if(contentMatch.length == 1){
+                        grunt.log.writeln("Found exactly 1 @VERSION@ in " + abspath);
+
+                        newContent = content.replace(token,VERSION);
+                        grunt.file.write(abspath, newContent); //overwrite old HISTORY.md
+                        grunt.log.writeln("Wrote " + VERSION + " to " + abspath);
+                        fileCount++;
+
+                    } else {
+                        grunt.log.error("Found " + contentMatch.length + " @VERSION@'s in " + abspath + " skipping...");
+                    }
+
+                } else {
+                    grunt.log.error("Found 0 @VERSION@'s in " + abspath + " skipping...");
+                }
+            }
+        });
+
+        grunt.log.writeln("History Version Replace done. Files changed: "+ fileCount);
+
+    });
+
+
+
+
+
+
+};

--- a/tasks/history.js
+++ b/tasks/history.js
@@ -141,3 +141,4 @@ module.exports = function(grunt) {
 
 
 };
+

--- a/tests/tasks.js
+++ b/tests/tasks.js
@@ -21,7 +21,7 @@ var tests = {
         topic: function() {
             return tasks.length;
         },
-        'and find 38 tasks': function(topic) {
+        'and find 41 tasks': function(topic) {
             assert.equal(41, topic);
         }
     }

--- a/tests/tasks.js
+++ b/tests/tasks.js
@@ -22,7 +22,7 @@ var tests = {
             return tasks.length;
         },
         'and find 38 tasks': function(topic) {
-            assert.equal(38, topic);
+            assert.equal(41, topic);
         }
     }
 };


### PR DESCRIPTION
This is a set of history related tasks that Dav asked to be added to grunt-yui-contrib.

**history-rollup**, Creates History Rollup file (Run before history-replace)
**history-populate**, Populates History files with @VERSION@ if not there already 
(actually adds the whole entry e.g.

```
@VERSION@
------

* No changes.
```

)

**history-replace**, Replaces @VERSION@ in History files with _release-version_
