### PR TITLE
Add `bower-install` task

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "grunt": "~0.4.1",
         "yui-lint": "~0.1.1",
         "jshint": "~0.9.0",
-        "istanbul": "~0.1.8"
+        "istanbul": "~0.1.8",
+        "bower": "~1.2.5"
     },
     "keywords": [
         "yui", "grunt"

--- a/tasks/bower.js
+++ b/tasks/bower.js
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2013, Yahoo! Inc. All rights reserved.
+Code licensed under the BSD License:
+http://yuilibrary.com/license/
+*/
+
+var bower = require('bower');
+
+module.exports = function (grunt) {
+    grunt.registerTask('bower-install', 'Installs Bower dependencies.', function () {
+        var done = this.async();
+
+        bower.commands.install()
+            .on('log', function (data) {
+                if (data.id !== 'install') { return; }
+                grunt.log.writeln('bower ' + data.id.cyan + ' ' + data.message);
+            })
+            .on('end', function (results) {
+                if (!Object.keys(results).length) {
+                    grunt.log.writeln('No bower packages to install.');
+                }
+
+                done();
+            });
+    });
+};

--- a/tests/tasks.js
+++ b/tests/tasks.js
@@ -21,8 +21,8 @@ var tests = {
         topic: function() {
             return tasks.length;
         },
-        'and find 42 tasks': function(topic) {
-            assert.equal(42, topic);
+        'and find 43 tasks': function(topic) {
+            assert.equal(43, topic);
         }
     }
 };
@@ -31,7 +31,7 @@ var tests = {
 tasks.forEach(function(name) {
     tests['should have ' + name] = {
         topic: function() {
-            return grunt.task._tasks[name]
+            return grunt.task._tasks[name];
         },
         'should be an object': function(topic) {
             assert.isObject(topic);


### PR DESCRIPTION
This adds a task to install Bower packages.

All the other Grunt + Bower tasks didn't fit with what we needed, so this is a simple one jacked from Pure's Gruntfile.js.
