### PR TITLE
Add Bower tasks to build task

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -10,9 +10,9 @@ module.exports = function(grunt) {
             grunt.log.ok('Found GRUNT_SKIP_BUILD in environment, skipping build.');
         });
     } else {
-        grunt.registerTask('build', 'Building YUI', ['yogi-build', 'npm']);
+        grunt.registerTask('build', 'Building YUI', ['bower-install', 'yogi-build', 'npm']);
     }
-    grunt.registerTask('build-test', 'Building and testing YUI', ['yogi-build', 'npm', 'test']);
+    grunt.registerTask('build-test', 'Building and testing YUI', ['bower-install', 'yogi-build', 'npm', 'test']);
     grunt.registerTask('all', 'Building and testing YUI', ['build-test']);
 };
 


### PR DESCRIPTION
`grunt build` should call `bower install` before `yogi build` and the rest of the build process.
