### PR TITLE
Addition of an alternative to skip building.

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -5,7 +5,9 @@ http://yuilibrary.com/license/
 */
 
 module.exports = function(grunt) {
-    if ('GRUNT_SKIP_BUILD' in process.env) {
+    // The `artifacts` directory will usually only ever in YUI's CI system.
+    // If you're in CI, and `build-npm` exists (meaning YUI's already built), skip the build.
+    if ((grunt.file.exists('artifacts') && grunt.file.exists('build-npm')) || 'GRUNT_SKIP_BUILD' in process.env) {
         grunt.registerTask('build', 'Building YUI', function() {
             grunt.log.ok('Found GRUNT_SKIP_BUILD in environment, skipping build.');
         });


### PR DESCRIPTION
In YUI's CI system, it is nearly impossible to modify environment variables, and thus the current method of skipping builds is insufficient. This change simply makes it easier for CI to skip building YUI. 

As mentioned, the `artifacts` directory usually only exists in CI. A normal user normally won't have this directory created. This change should be safe.
